### PR TITLE
Clean up index.md contributers and links

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@
 
 ### Live Online Copy:
 
-You can find a copy of the project online at: http://PwnWiki.io
+You can find a copy of the project online at: http://pwnwiki.io
 
 ### Offline Use:
 
@@ -27,12 +27,12 @@ We realize that not everyone can/wants to submit content via GitHub and that's c
 - - - - - -
 Curators:
 
-  * [@mubix](https://twitter.com/mubix) [gimmick:TwitterFollow](@mubix)
-  * [@WebBreacher](https://twitter.com/webbreacher) [gimmick:TwitterFollow](@WebBreacher)
-  * [@tekwizz123](https://twitter.com/tekwizz123) [gimmick:TwitterFollow](@tekwizz123)
-  * [@jakx_](https://twitter.com/jakx_) [gimmick:TwitterFollow](@jakx_)
-  * [@TheColonial](https://twitter.com/TheColonial) [gimmick:TwitterFollow](@TheColonial)
-  * [@Wireghoul](https://twitter.com/Wireghoul) [gimmick:TwitterFollow](@Wireghoul)
+  * [@mubix](https://twitter.com/mubix)
+  * [@WebBreacher](https://twitter.com/webbreacher)
+  * [@tekwizz123](https://twitter.com/tekwizz123)
+  * [@jakx_](https://twitter.com/jakx_)
+  * [@TheColonial](https://twitter.com/TheColonial)
+  * [@Wireghoul](https://twitter.com/Wireghoul)
   
 
 If you would like to become a curator, please contact [mubix@hak5.org](mailto:mubix@hak5.org)


### PR DESCRIPTION
Cleaned up a case where there were two links to contributer's twitter accounts on the main page and a case where the link was displayed as http://PwnWiki.com rather than http://pwnwiki.com, which might cause some confusion to people.
