### PR TITLE
Add in changes from "No Wireshark? No TCPDump? No problem!"

### DIFF
--- a/scripting/windows.md
+++ b/scripting/windows.md
@@ -16,3 +16,15 @@ reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server" /v fDenyTSConnec
 ```bash
 for /L %i in (1,1,255) do @start /b ping -n 1 -w 1 192.168.1.%i
 ```
+
+**Capture all IPv4 traffic, TCP only, which matches the IP address on a 64 bit Windows 7/Windows 2008 
+or newer box, continue the capture even if the computer restarts, save capture to a nondefault location. 
+Captures can then be analysed with Microsoft's Message Analyser
+http://www.microsoft.com/en-us/download/details.aspx?id=44226**
+```bash
+netsh trace start capture=yes Ethernet.Type=IPv4  IPv4.Address=157.59.136.1 Protocol=TCP persistent=yes traceFile=C:\Users\Public\trace.etl
+```
+**Stop the capture**
+```bash
+netsh trace stop
+```


### PR DESCRIPTION
Add in changes from https://isc.sans.edu/forums/diary/No+Wireshark+No+TCPDump+No+Problem/19409/ on how to use netsh trace to capture packets without installing anything else on Windows 64 bit machines with Windows 7/Windows Server 2008 or newer.